### PR TITLE
Fix typo: tls_cer -> tls_cert

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
       skip: true
       paths:
         - '{{role_path}}/vars'
-    
+
 - name: templatize
   become: yes
   become_user: root
@@ -27,4 +27,3 @@
     src: '{{item.f}}.j2'
     dest: '{{item.d}}/{{item.f}}'
     mode: '{{item.m}}'
-    

--- a/templates/nslcd.conf.j2
+++ b/templates/nslcd.conf.j2
@@ -132,7 +132,7 @@ tls_ciphers {{nss_pam_ldap_tls_ciphers}}
 # Client certificate and key
 # Use these, if your server requires client authentication.
 {% if nss_pam_ldap_tls_cert is defined %}
-tls_cer {{nss_pam_ldap_tls_cert}}
+tls_cert {{nss_pam_ldap_tls_cert}}
 {% else %}
 #tls_cert
 {% endif %}


### PR DESCRIPTION
This PR fixes a typo and removes some trailing whitespace (so `ansible-lint` doesn't complain).