### PR TITLE
change mode of nsswitch to 644

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
       m: '0600'
     - f: nsswitch.conf
       d: /etc
-      m: '0600'
+      m: '0644'
     - f: ldap
       d: /etc/pam.d
       m: '0600'


### PR DESCRIPTION
Without read access to nsswitch.conf, non-root users are unable to use ldap to resolve names.

For example details, see: https://unixsherpa.com/solution/etchosts-entries-not-being-used-for-non-root-users/